### PR TITLE
fix: Saveguard against invalid comparison in pandas comparator

### DIFF
--- a/tabulardelta/comparators/pandas_comparator.py
+++ b/tabulardelta/comparators/pandas_comparator.py
@@ -290,7 +290,9 @@ def compare_pandas(
                 left, right, float_rtol, float_atol, True
             )
         else:
-            joined[col + "_equal"] = (left == right).fillna(False) | pd.isna(left) & pd.isna(right)
+            joined[col + "_equal"] = (left == right).fillna(False) | pd.isna(
+                left
+            ) & pd.isna(right)
         unequal = joined[~joined[col + "_equal"].astype("bool")]
         change = _value_change(unequal, join_columns, col, suffixes, old_dt, new_dt)
         if len(change) > 0:

--- a/tabulardelta/comparators/pandas_comparator.py
+++ b/tabulardelta/comparators/pandas_comparator.py
@@ -290,7 +290,7 @@ def compare_pandas(
                 left, right, float_rtol, float_atol, True
             )
         else:
-            joined[col + "_equal"] = (left == right) | pd.isna(left) & pd.isna(right)
+            joined[col + "_equal"] = (left == right).fillna(False) | pd.isna(left) & pd.isna(right)
         unequal = joined[~joined[col + "_equal"].astype("bool")]
         change = _value_change(unequal, join_columns, col, suffixes, old_dt, new_dt)
         if len(change) > 0:


### PR DESCRIPTION
# Motivation

See https://github.com/Quantco/tabulardelta/issues/7

# Changes

Add a safeguard against invalid comparisons in `PandasComparator`

Reviewer: @AaronTacke Could you have a look at this? If you are fine with merging could we do a release including this fix?
