### PR TITLE
refactor: Make Pandas optional

### DIFF
--- a/tabulardelta/comparators/pandas_comparator.py
+++ b/tabulardelta/comparators/pandas_comparator.py
@@ -154,7 +154,7 @@ def _value_change(
     diff.rename(columns={col + suffixes[1]: col}, inplace=True)
     diff["_count"] = 1
     combined = col, old_dt[col], col, new_dt[col], False
-    return ColumnPair.from_str(*combined, incomparable, diff)
+    return ColumnPair.from_str(*combined, incomparable, diff.to_dict("records"))
 
 
 def compare_pandas(

--- a/tabulardelta/comparators/sqlcompyre_comparator.py
+++ b/tabulardelta/comparators/sqlcompyre_comparator.py
@@ -96,12 +96,16 @@ class SqlCompyreComparator:
         removed_rows = _get_sample(self.engine, rows.unjoined_left, self.row_samples)
 
         return TabularDelta(
-            new
-            if isinstance(new, str)
-            else getattr(getattr(right, "original"), "name", ""),
-            old
-            if isinstance(old, str)
-            else getattr(getattr(left, "original"), "name", ""),
+            (
+                new
+                if isinstance(new, str)
+                else getattr(getattr(right, "original"), "name", "")
+            ),
+            (
+                old
+                if isinstance(old, str)
+                else getattr(getattr(left, "original"), "name", "")
+            ),
             _columns=incomparable + comparable + uncompared,
             _old_rows=comp.row_counts.left,
             _new_rows=comp.row_counts.right,
@@ -208,8 +212,9 @@ def _get_value_change(
     except (sa.exc.ProgrammingError, sa.exc.DataError):
         warn(f"Couldn't get value change for {name}.")
         result = pd.DataFrame({old_name: None, new_name: None, "_count": [total]})
+    result.columns = result.columns.astype(str)
     return ColumnPair.from_sqlalchemy(
-        original_old, original_new, False, not comparable, result
+        original_old, original_new, False, not comparable, result.to_dict("records")
     )
 
 

--- a/tests/test_comparators.py
+++ b/tests/test_comparators.py
@@ -140,8 +140,9 @@ def test_pandas_comparator():
     assert "paid" in incomparable_dtype_dict
     assert incomparable_dtype_dict["paid"][2] == "object"
     assert incomparable_dtype_dict["paid"][3] == "bool"
-    assert isinstance(incomparable_dtype_dict["paid"][4], pd.DataFrame)
-    cols = incomparable_dtype_dict["paid"][4].columns
+    assert incomparable_dtype_dict["paid"][4] is not None
+    assert len(incomparable_dtype_dict["paid"][4]) > 0
+    cols = incomparable_dtype_dict["paid"][4][0].keys()
     assert "name" in cols
     assert "_count" in cols
     assert incomparable_dtype_dict["paid"][0] in cols
@@ -150,12 +151,13 @@ def test_pandas_comparator():
     assert "id" in incomparable_dtype_dict
     assert incomparable_dtype_dict["id"][2] == "int64"
     assert incomparable_dtype_dict["id"][3] == "float64"
-    assert isinstance(incomparable_dtype_dict["id"][4], pd.DataFrame)
-    cols = incomparable_dtype_dict["id"][4].columns
+    assert incomparable_dtype_dict["id"][4] is not None
+    assert len(incomparable_dtype_dict["id"][4]) > 0
+    cols = incomparable_dtype_dict["id"][4][0].keys()
     assert "name" in cols
     assert "_count" in cols
-    assert incomparable_dtype_dict["id"][0] in incomparable_dtype_dict["id"][4].columns
-    assert incomparable_dtype_dict["id"][1] in incomparable_dtype_dict["id"][4].columns
+    assert incomparable_dtype_dict["id"][0] in cols
+    assert incomparable_dtype_dict["id"][1] in cols
 
     assert len(delta.rows.old) == 10
     assert len(delta.rows.new) == 11
@@ -209,19 +211,21 @@ def test_pandas_comparator():
     actual_differences = [diff for diff in delta.cols.differences if len(diff) > 0]
     assert len(actual_differences) == 1
     assert actual_differences[0].new and actual_differences[0].new.name == "expectation"
-    df = actual_differences[0]._values
-    assert df is not None
-    assert actual_differences[0].old and actual_differences[0].old.name in df.columns
-    assert actual_differences[0].new and actual_differences[0].new.name in df.columns
+    changes = actual_differences[0]._values
+    assert changes is not None
+    assert len(changes) > 0
+    cols = changes[0].keys()
+    assert actual_differences[0].old and actual_differences[0].old.name in cols
+    assert actual_differences[0].new and actual_differences[0].new.name in cols
     expected_df = pd.DataFrame(
         {
+            "name": ["E"],
             "expectation_old": [0.5],
             "expectation": [0.55],
             "_count": [1],
-            "name": ["E"],
         }
     )
-    assert_frame_equal(df.reset_index(drop=True), expected_df.reset_index(drop=True))
+    assert_frame_equal(pd.DataFrame(changes), expected_df.reset_index(drop=True))
 
 
 def test_pandas_comparator_row_col_orders():
@@ -323,8 +327,9 @@ def test_sqlcompyre_comparator(mssql_engine: sa.Engine, input_type: str):
         == 'VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS"'
     )
     assert incomparable_dtype_dict["paid"][3] == "BIT"
-    assert isinstance(incomparable_dtype_dict["paid"][4], pd.DataFrame)
-    cols = incomparable_dtype_dict["paid"][4].columns
+    assert incomparable_dtype_dict["paid"][4] is not None
+    assert len(incomparable_dtype_dict["paid"][4]) > 0
+    cols = incomparable_dtype_dict["paid"][4][0].keys()
     assert "name" in cols
     assert "_count" in cols
     assert incomparable_dtype_dict["paid"][0] in cols
@@ -377,20 +382,21 @@ def test_sqlcompyre_comparator(mssql_engine: sa.Engine, input_type: str):
     assert actual_differences[0].new
     assert actual_differences[0].old
     assert actual_differences[0].new.name == "expectation"
-    df = actual_differences[0]._values
-    assert df is not None
-    assert actual_differences[0].old.name in df.columns
-    assert actual_differences[0].new.name in df.columns
+    diff_values = actual_differences[0]._values
+    assert diff_values is not None
+    assert len(diff_values) > 0
+    assert actual_differences[0].old.name in diff_values[0].keys()
+    assert actual_differences[0].new.name in diff_values[0].keys()
     expected = pd.DataFrame(
         {
-            "expectation_old": [0.5],
             "expectation": [0.55],
+            "expectation_old": [0.5],
             "_count": [1],
             "name": ["E"],
         }
     )
     assert_frame_equal(
-        df.reset_index(drop=True), expected.reset_index(drop=True), check_dtype=False
+        pd.DataFrame(diff_values), expected.reset_index(drop=True), check_dtype=False
     )
 
 

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -60,25 +60,29 @@ def get_random_tabulardelta(gen: np.random.Generator):
     ) -> ColumnPair:
         if chg.old is None or chg.new is None:
             raise ValueError("Can't generate values for non-matched columns.")
-        size = cast(int, gen.integers(0, 2 ** gen.integers(0, 10)))
+        size = gen.integers(0, 2 ** gen.integers(0, 10))
         old_renamed = Column(
             chg.old.name + ("_old" if chg.old.name == chg.new.name else ""),
             chg.old.type,
         )
-        indexes = {col.name: gen_col_values(col.type, size) for col in join_columns}
+        indexes = {
+            col.name: gen_col_values(col.type, cast(int, size)) for col in join_columns
+        }
         df = pd.DataFrame(
             {
-                old_renamed.name: gen_col_values(chg.old.type, size),
-                chg.new.name: gen_col_values(chg.new.type, size),
+                old_renamed.name: gen_col_values(chg.old.type, cast(int, size)),
+                chg.new.name: gen_col_values(chg.new.type, cast(int, size)),
                 **indexes,
-                "_count": gen_col_values("uint64", size).astype("int"),
+                "_count": gen_col_values("uint64", cast(int, size)).astype("int"),
             }
         )
         if gen.random() < 0.5:
             additional = gen.integers(0, 10 ** gen.integers(0, 8))
             df.loc[len(df)] = [None] * (2 + len(join_columns)) + [additional]
             df["_count"] = df["_count"].astype("int")
-        return ColumnPair(chg.old, chg.new, incomparable=incomparable, _values=df)
+        return ColumnPair(
+            chg.old, chg.new, incomparable=incomparable, _values=df.to_dict("records")
+        )
 
     def gen_change() -> ColumnPair:
         old = gen_col_meta()


### PR DESCRIPTION
# Motivation

We don't want Pandas as an optional requirement, especially once a Polars Comparator (see #15) will be added.

# Changes

Use native python data structures to replace Pandas in the parts of the comparator implementation that are used by multiple comparators.

# TODOS

- [ ] Check for other usages of Pandas in general (non-Pandas specific) files.
- [ ] Remove Pandas as dependency from pixi, create an environment with Pandas, change tests which require Pandas accordingly.
- [ ] Benchark comparisons with many changes (large `_values` in tabulardelta_dataclasses)